### PR TITLE
Extracted Http\Transport from Http\Client

### DIFF
--- a/classes/Ergo/Http/Transport.php
+++ b/classes/Ergo/Http/Transport.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Ergo\Http;
+
+class Transport
+{
+	private $_timeout = 10;
+	private $_proxy;
+	private $_auth;
+
+	public function send($request)
+	{
+		// prepare and send the curl request
+		$curl = $this->_curlConnection($request);
+		if(($curlResponse = curl_exec($curl)) === false)
+		{
+			throw new Error('Curl error: ' . curl_error($curl),
+				curl_errno($curl));
+		}
+
+		$response = $this->_buildResponse($curlResponse);
+
+		curl_close($curl);
+
+		return $response;
+	}
+
+	public function setTimeout($seconds)
+	{
+		$this->_timeout = $seconds;
+	}
+
+	public function setHttpProxy($url)
+	{
+		$this->_proxy = $url;
+	}
+
+	public function setHttpAuth($user, $pass)
+	{
+		$this->_auth = $user . ':' . $pass;
+	}
+
+
+	/**
+	 * Initializes the curl connection
+	 */
+	private function _curlConnection($request)
+	{
+		// create a new curl resource
+		$curl = curl_init();
+		$method = $request->getRequestMethod();
+		$headers = array('Expect:');
+
+		// add existing headers into a flat string format
+		foreach($request->getHeaders() as $header)
+		{
+			$headers[] = rtrim($header->__toString());
+		}
+
+		// set URL and other appropriate options
+		curl_setopt($curl, CURLOPT_URL, $request->getUrl());
+		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($curl, CURLOPT_HEADER, true);
+		curl_setopt($curl, CURLOPT_VERBOSE, false);
+		curl_setopt($curl, CURLOPT_TIMEOUT, $this->_timeout);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, false);
+		curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
+
+		// enable proxy support
+		if(isset($this->_proxy))
+		{
+			curl_setopt($curl, CURLOPT_PROXY, $this->_proxy);
+		}
+
+		// enable http authentication
+		if(isset($this->_auth))
+		{
+			curl_setopt($curl, CURLOPT_USERPWD, $this->_auth);
+			curl_setopt($curl, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+		}
+
+		if($method == 'PUT' || $method == 'POST')
+		{
+			$headers[] = 'Content-Length: '.strlen($request->getBody());
+
+			curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+			curl_setopt($curl, CURLOPT_POSTFIELDS, $request->getBody());
+		}
+		elseif($method == 'DELETE')
+		{
+			curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $method);
+		}
+
+		// add HTTP headers
+		curl_setopt($curl, CURLOPT_HTTPHEADER, $headers);
+
+		return $curl;
+	}
+
+	/**
+	 * Parses a response into headers and a body
+	 */
+	private function _buildResponse($response)
+	{
+		$sections = explode("\r\n\r\n", $response,2);
+		$body = isset($sections[1]) ? $sections[1] : NULL;
+		$headers = array();
+		$headerlines = explode("\n",$sections[0]);
+
+		// process status
+		list($http, $code, $message) = explode(' ',$headerlines[0],3);
+
+		// process headers
+		foreach(array_slice($headerlines,1) as $headerline)
+		{
+			$headers[] = HeaderField::fromString($headerline);
+		}
+
+		$response = new Response($code,$headers,$body);
+
+		return $response;
+	}
+}

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Ergo\Http;
+
+\Mock::generate('Ergo\Http\Transport', 'MockTransport');
+
+class ClientTest extends \UnitTestCase
+{
+	public function transport()
+	{
+		$transport = new \MockTransport();
+		return Client::transport($transport);
+	}
+
+	public function client()
+	{
+		return new Client('http://example.org');
+	}
+
+	public function testRequestMethodsDelegateToTransport()
+	{
+		$methods = array('GET', 'POST', 'PUT', 'DELETE');
+		foreach ($methods as $method)
+		{
+			$transport = $this->transport();
+			$transport->expectOnce(
+				'send',
+				array(new \IsAExpectation('\Ergo\Http\Request')),
+				"Expect $method to delegate to send with Request: %s"
+			);
+			$transport->setReturnValue(
+				'send', new Response(200, array())
+			);
+			$client = new Client('http://example.org');
+			$this->client()->$method('/hello', 'content');
+		}
+	}
+
+	public function testInternalServerErrorStatusCodeThrowsException()
+	{
+		$this->transport()->setReturnValue('send', new Response(500, array()));
+
+		$this->expectException('Ergo\Http\Error');
+
+		$this->client()->get('/hello');
+	}
+}


### PR DESCRIPTION
Refactored the Http\Client class such that all code dealing directly with curl now resides in Http\Transport, this will enable certain types of testing/mocking that wasn't previously possible when dealing with the Http\Client.

Obviously a lot of fairly important code depends on this so it warrants a fair degree of scrutiny, a means to properly test the Transport would be nice too.

Additionally the Transport has three methods on it: setTimeout, setHttpProxy & setHttpAuth. These three methods don't really feel like they belong on this class, but as yet I've come up with no solution for removing them, idea's welcome.
