### PR TITLE
Request & Response now support returning simplified versions of themselves

### DIFF
--- a/classes/Ergo/Http/Request.php
+++ b/classes/Ergo/Http/Request.php
@@ -98,4 +98,17 @@ class Request
 
 		return $copy;
 	}
+
+	/**
+	 * @return array
+	 */
+	public function export()
+	{
+		return array(
+			$this->getRequestMethod(),
+			(string)$this->getUrl(),
+			$this->getHeaders()->toArray($crlf = false),
+			$this->getBody()
+		);
+	}
 }

--- a/classes/Ergo/Http/Response.php
+++ b/classes/Ergo/Http/Response.php
@@ -55,4 +55,16 @@ class Response
 	{
 		return $this->_body;
 	}
+
+	/**
+	 * @return array
+	 */
+	public function export()
+	{
+		return array(
+			$this->getStatus()->getCode(),
+			$this->getHeaders()->toArray($crlf = false),
+			(string)$this->getBody()
+		);
+	}
 }

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -28,6 +28,26 @@ class RequestTest extends \UnitTestCase
 			));
 	}
 
+	public function testExport()
+	{
+		$request = new Request(
+			Request::METHOD_GET,
+			'http://example.org',
+			array('Accept: text/html'),
+			'test data'
+		);
+
+		$this->assertEqual(
+			$request->export(),
+			array(
+				'GET',
+				'http://example.org/',
+				array('Accept: text/html'),
+				'test data',
+			)
+		);
+	}
+
 	public function testRequestFactoryWithAbsoluteUrlInEnvironment()
 	{
 		$server = array(

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -42,5 +42,20 @@ class ResponseTest extends \UnitTestCase
 		$this->assertEqual($response->getHeaders()->value('Content-Length'),6);
 	}
 
+	public function testExport()
+	{
+		$response = new Http\Response(
+			200, array('Content-Type: text/html'), 'Food goes in here'
+		);
+
+		$this->assertEqual(
+			$response->export(),
+			array(
+				200,
+				array('Content-Type: text/html'),
+				'Food goes in here',
+			)
+		);
+	}
 
 }


### PR DESCRIPTION
Added an `export` method to request and response which returns all their data as primitive values. The motivation for this is to provide a narrower interface for requests and responses to make testing against them easier.

Why is testing against the request/response interface difficult? Primarily the issue is with the number of objects they expose (HeaderCollection, HeaderField, Status, Url). Normally this wouldn't be a problem for tests against libraries which are dependant upon Ergo and thus include it as part of their codebase, they'd simply created standard requests and responses and get those objects for free. 

For libraries which support Ergo but don't require it, the situation is somewhat different. Since Ergo isn't included directly, mocks/stubs must take the place of the request/response objects, as well as all of the other objects they expose. Unsurprisingly stubbing 5 objects just to get 1 gets old very fast. Providing a narrower interface to export the objects data would greatly simplify this.

Thoughts? :suspect:
