### PR TITLE
Use Composer to manage development dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.pear.tmp
-vendor/simpletest
+/composer.lock
+/vendor

--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ Status
 
 Used in several high-volume production websites, including 99designs.com, flippa.com, learnable.com and sitepoint.com.
 
-[1](https://github.com/composer/composer)
+[1]: https://github.com/composer/composer

--- a/README.md
+++ b/README.md
@@ -36,14 +36,12 @@ Basic Usage
 How to develop
 -----------------
 
-For running, Ergo has no external dependancies. For development [Pundle](https://github.com/T-Moe/Pundle) is used to pull
-in SimpleTest as a dependancy.
+For running, Ergo has no external dependancies. For development [Composer][1] is
+used to pull in SimpleTest as a dependancy.
 
-To install dependancies via Pundle:
+To install dependancies via Composer:
 
-	$ pear channel-discover pear.webzeile.de
-	$ pear install webzeile/Pundle
-	$ pundle install
+	$ composer install --dev
 
 Run the test suite:
 
@@ -56,3 +54,4 @@ Status
 
 Used in several high-volume production websites, including 99designs.com, flippa.com, learnable.com and sitepoint.com.
 
+[1](https://github.com/composer/composer)

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,9 @@
     "require": {
         "php": ">=5.3.0"
     },
+    "require-dev": {
+        "lastcraft/simpletest": ">=1.1.0"
+    },
     "autoload": {
         "psr-0": {
             "Ergo": "classes"

--- a/runtests.php
+++ b/runtests.php
@@ -7,7 +7,7 @@ require_once(BASEDIR.'/classes/Ergo/ClassLoader.php');
 $classloader = new \Ergo\ClassLoader();
 $classloader->register()->includePaths(array(
 	BASEDIR."/classes",
-	BASEDIR."/vendor/simpletest",
+	BASEDIR."/vendor/lastcraft/simpletest",
 	));
 
 $options = new \Ergo\Console\Options($argv, array(


### PR DESCRIPTION
Use Composer instead of Pundle to install simpletest during development.

Ping @lox
