### PR TITLE
RequestFactory uses HTTP_HOST instead of SERVER_PORT

### DIFF
--- a/classes/Ergo/Http/RequestFactory.php
+++ b/classes/Ergo/Http/RequestFactory.php
@@ -63,20 +63,11 @@ class RequestFactory implements \Ergo\SingletonFactory
 	private function _getUrl()
 	{
 		return new Url(sprintf(
-			'%s://%s:%d%s',
+			'%s://%s%s',
 			$this->_getScheme(),
-			$this->_server['SERVER_NAME'],
-			$this->_getPort(),
+			$this->_server['HTTP_HOST'],
 			$this->_uriRelativeToHost($this->_server['REQUEST_URI'])
 		));
-	}
-
-	private function _getPort()
-	{
-		return $this->_getSchemeHeader() == 'https'
-			? '443'
-			: $this->_server['SERVER_PORT']
-			;
 	}
 
 	private function _getSchemeHeader()


### PR DESCRIPTION
The app environment should use the host and port that user's browser
actually requested.
The host and port the server is running on shouldn't affect the
functionality of the app, especially in environments where servers
are running behind reverse proxies etc where the SERVER_PORT could
be different to what the user facing app uses.
