### PR TITLE
WebErrorHandler clears all output buffers before sending a response

### DIFF
--- a/classes/Ergo/Error/WebErrorHandler.php
+++ b/classes/Ergo/Error/WebErrorHandler.php
@@ -60,11 +60,13 @@ class WebErrorHandler extends AbstractErrorHandler
 				exit(0);
 			}
 
+			while (ob_get_level() > 0)
+				ob_end_clean();
+
 			// send it off
 			$sender = new Http\ResponseSender($this->buildResponse($e));
 			$sender->send();
 
-			if (ob_get_level() > 0) ob_flush();
 			exit(self::EXIT_CODE);
 		}
 	}


### PR DESCRIPTION
Fixes issues where if an error occurs when the output buffer has already been opened the error output isn't shown (e.g. within a view). Does this look like it could break anything terribly?

/cc @lox @dhotson @lwc 
