### PR TITLE
Restore the old array access interface for RouteMatch

### DIFF
--- a/classes/Ergo/Routing/RouteMatch.php
+++ b/classes/Ergo/Routing/RouteMatch.php
@@ -5,7 +5,7 @@ namespace Ergo\Routing;
 /**
  * A match result from a lookup against a {@link Router}
  */
-class RouteMatch implements \IteratorAggregate
+class RouteMatch extends \ArrayIterator
 {
 	private $_name;
 	private $_parameters;
@@ -21,6 +21,7 @@ class RouteMatch implements \IteratorAggregate
 		$this->_name = $name;
 		$this->_parameters = $parameters;
 		$this->_metadata = $metadata;
+		parent::__construct($parameters);
 	}
 
 	/**


### PR DESCRIPTION
This restores the old array access interface for RouteMatch without otherwise changing its interface. Considered a bug as this change merited a major version increase which didn't happen.
