### PR TITLE
V1: remove addFilter() type hints

### DIFF
--- a/classes/Ergo/Http/Client.php
+++ b/classes/Ergo/Http/Client.php
@@ -32,7 +32,7 @@ class Ergo_Http_Client
 	 * Adds an HTTP header to all requests
 	 * @chainable
 	 */
-	public function addFilter(Ergo_Http_ClientFilter $filter)
+	public function addFilter($filter)
 	{
 		$this->_filters[] = $filter;
 		return $this;

--- a/classes/Ergo/Routing/RequestFilterChain.php
+++ b/classes/Ergo/Routing/RequestFilterChain.php
@@ -21,7 +21,7 @@ class Ergo_Routing_RequestFilterChain
 		return $request;
 	}
 
-	public function addFilter(Ergo_Routing_RequestFilter $filter)
+	public function addFilter($filter)
 	{
 		$this->_filters[] = $filter;
 		return $this;


### PR DESCRIPTION
Removes type-hints from:
- `Ergo_Http_Client::addFilter()`
- `Ergo_Routing_RequestFilterChain::addFilter()`

This permits other libraries like `99designs/relax` to provide filters which work with both ergo v1 and v2.

The aim is to be able to upgrade an internal 99designs project to the latest relax, while keeping it on the ergo v1 branch.

See also https://github.com/99designs/ergo/pull/23 for ergo v2 master branch PR.
