### PR TITLE
V2: remove addFilter() type hints

### DIFF
--- a/classes/Ergo/Http/Client.php
+++ b/classes/Ergo/Http/Client.php
@@ -46,7 +46,7 @@ class Client
 	 * Adds an HTTP header to all requests
 	 * @chainable
 	 */
-	public function addFilter(ClientFilter $filter)
+	public function addFilter($filter)
 	{
 		$this->_filters[] = $filter;
 		return $this;

--- a/classes/Ergo/Routing/RequestFilterChain.php
+++ b/classes/Ergo/Routing/RequestFilterChain.php
@@ -22,7 +22,7 @@ class RequestFilterChain
 		return $request;
 	}
 
-	public function addFilter(RequestFilter $filter)
+	public function addFilter($filter)
 	{
 		$this->_filters[] = $filter;
 		return $this;


### PR DESCRIPTION
Removes type-hints from:

- `\Ergo\Http\Client::addFilter()`
- `\Ergo\Routing\RequestFilter::addFilter()`

This permits other libraries like `99designs/relax` to provide filters which work with both ergo v1 and v2.

The aim is to be able to upgrade an internal 99designs project to the latest relax, while keeping it on the ergo v1 branch.

See also https://github.com/99designs/ergo/pull/22 for ergo v1.x branch PR.